### PR TITLE
ubuntu-24.04: drop ubuntu user

### DIFF
--- a/dockerfiles/ubuntu/ubuntu-24.04/ubuntu-24.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-24.04/ubuntu-24.04-base/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    userdel -r ubuntu && \
     useradd -U -m yoctouser && \
     /usr/sbin/locale-gen en_US.UTF-8 && \
     echo 'dash dash/sh boolean false' | debconf-set-selections && \


### PR DESCRIPTION
Ubuntu 24.04 upstream base image now has a user "ubuntu" assigned uid/gid 1000. This conflicts with other CROPS images. It is currently preventing creation of "pokyuser" in poky-container, so remove this new user in our ubuntu-24.04 base to prevent the conflict.